### PR TITLE
Kirby Block für Informations-Boxen

### DIFF
--- a/assets/css/templates/internal/infobox.css
+++ b/assets/css/templates/internal/infobox.css
@@ -1,0 +1,65 @@
+@keyframes infobox-dot-anim {
+  0% {
+    opacity: 0;
+  }
+  5% {
+    opacity: 1;
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.infobox {
+  --infobox-color: #1187cc;
+  margin: 24px 0px;
+  padding: 0px;
+  border: 2px solid var(--infobox-color);
+  border-radius: 4px;
+
+  &.infobox-alert {
+    --infobox-color: #cc2211;
+  }
+
+  .infobox-title {
+    position: relative;
+    margin: 0px;
+    padding: 8px 12px;
+    background-color: var(--infobox-color);
+    color: #ffffff;
+  }
+
+  &.infobox-alert .infobox-title {
+    padding-left: 45px;
+  }
+
+  &.infobox-alert .infobox-title::before {
+    content: ' ';
+    position: absolute;
+    display: block;
+    width: 45px;
+    height: 100%;
+    top: 0px;
+    left: 0px;
+    background-color: white;
+    clip-path: circle(8px);
+    animation-name: infobox-dot-anim;
+    animation-duration: 1.2s;
+    animation-iteration-count: infinite;
+  }
+
+  .infobox-content {
+    margin: 0px;
+    padding: 8px 12px;
+    font-size: larger;
+    h2, p {
+      border: none;
+      margin-top: 8px;
+      margin-bottom: 8px;
+      font-weight: normal;
+    }
+  }
+}

--- a/site/blueprints/pages/internal-blocks.yml
+++ b/site/blueprints/pages/internal-blocks.yml
@@ -5,6 +5,18 @@ fields:
     label: Text
     type: blocks
     pretty: true
+    fieldsets:
+      - heading
+      - text
+      - list
+      - quote
+      - infobox
+      - image
+      - gallery
+      - video
+      - code
+      - markdown
+      - line
   collapsedByDefault:
     type: toggle
     label: Collapsed by default in menu?

--- a/site/plugins/werkstatt/blueprints/blocks/infobox.yml
+++ b/site/plugins/werkstatt/blueprints/blocks/infobox.yml
@@ -1,0 +1,28 @@
+name: Infobox
+type: infobox
+icon: info-card
+preview: fields
+wysiwyg: true
+fields:
+  design:
+    label: 'Typ'
+    type: radio
+    options:
+      news: Aktuelles
+      info: Allgemeine Info
+    default: news
+    required: true
+  title:
+    label: Titel
+    type: text
+    required: true
+  text:
+    label: Text
+    type: textarea
+    required: true
+  date:
+    label: Datum
+    type: date
+  time:
+    label: Uhrzeit
+    type: time

--- a/site/plugins/werkstatt/index.php
+++ b/site/plugins/werkstatt/index.php
@@ -8,10 +8,12 @@ Kirby::plugin(
   'welcome-werkstatt/werkstatt',
   [
     'blueprints' => [
-      'blocks/embed' => __DIR__ . '/blueprints/blocks/embed.yml'
+      'blocks/embed' => __DIR__ . '/blueprints/blocks/embed.yml',
+      'blocks/infobox' => __DIR__ . '/blueprints/blocks/infobox.yml'
     ],
     'snippets' => [
-      'blocks/embed' => __DIR__ . '/snippets/blocks/embed.php'
+      'blocks/embed' => __DIR__ . '/snippets/blocks/embed.php',
+      'blocks/infobox' => __DIR__ . '/snippets/blocks/infobox.php'
     ],
     'tags' => [
       'external' => [

--- a/site/plugins/werkstatt/snippets/blocks/infobox.php
+++ b/site/plugins/werkstatt/snippets/blocks/infobox.php
@@ -1,0 +1,13 @@
+<div class="infobox <?= $block->design() == 'news' ? 'infobox-alert' : 'infobox-info' ?>">
+  <h2 class="infobox-title"><?= $block->design() == 'news' ? 'Aktuelles' : 'Info' ?></h2>
+  <div class="infobox-content">
+    <h2><?= $block->title() ?></h2>
+    <?php if ($block->date() != '' or $block->time() != '') { ?>
+      <p>
+        <?= $block->date() != '' ? $block->date()->toDate('🗓️ d.m.Y') : '' ?>
+        <?= $block->date() != '' ? $block->time()->toDate('🕓 H:i') : '' ?>
+      </p>
+    <?php } ?>
+    <p><?= $block->text() ?></p>
+  </div>
+</div>

--- a/site/snippets/internal/header.php
+++ b/site/snippets/internal/header.php
@@ -9,7 +9,8 @@
     'assets/css/templates/internal/github-markdown.css',
     'assets/css/templates/internal/parvus.min.css',
     'assets/css/templates/internal/sortable.css',
-    'assets/css/templates/internal/internal.css'
+    'assets/css/templates/internal/internal.css',
+    'assets/css/templates/internal/infobox.css'
   ]) ?>
   <?= js(['assets/js/templates/sortable.js','assets/js/templates/collapsible.js', 'assets/js/templates/parvus.min.js']) ?>
   <title><?= $page->title() ?> – Welcome Werkstatt Interner Bereich</title>

--- a/site/snippets/internal/menu.php
+++ b/site/snippets/internal/menu.php
@@ -8,7 +8,7 @@
     </button>
   </div>
   <?php
-  $items = $pages->template('internal')->first()->children()->listed();
+  $items = page('internes')->children()->listed();
   if ($items->isNotEmpty()) :
   ?>
     <ul class="padding no-margin flex-1 overflow-auto">


### PR DESCRIPTION
Fügt einen neuen Block hinzu welcher Informationen hervorhebt.

Unterstützt zwei Varianten:
- Aktuelles (rot mit blinkendem Punkt für mehr Aufmerksamkeit)
- Allgemeine Info (blau und ohne blinkenden Punkt)

<img width="824" height="250" alt="image" src="https://github.com/user-attachments/assets/afb69d99-ecd0-40bd-9169-25b32b044981" />

<img width="824" height="215" alt="image" src="https://github.com/user-attachments/assets/3e2d8d25-1d47-4528-a97f-35d746a01040" />

# ToDo

@pReya ich habe in diesem PR nur den Block hinzugefügt. Um den auf der internen Startseite verwenden zu können muss dann noch das genutze Template im content repo von `internal` zu `internal-blocks` geändert werden.
